### PR TITLE
Fix issue 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Tumblr
-workspace to make Tumblr more Indieweb friendly 
+# tumblr
+workspace to make Tumblr more indieweb friendly 
 
-The first pass is to update the Tumblr template to use [microformats-2 markup](http://microformats.org/wiki/microformats2) for _post_ kinds.
+The first pass is to update the tumblr template to use microformats-2 markup for post kinds.
 
-An example Tumblr blog with this template is at https://indieweb-test.tumblr.com/
+An example tumblr blog with thsi template is at https://indieweb-test.tumblr.com/
 
 This parses like this: https://xray.p3k.app/parse?url=https%3A%2F%2Findieweb-test.tumblr.com&pretty=true
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# tumblr
-workspace to make Tumblr more indieweb friendly 
+# Tumblr
+workspace to make Tumblr more Indieweb friendly 
 
-The first pass is to update the tumblr template to use microformats-2 markup for post kinds.
+The first pass is to update the Tumblr template to use [microformats-2 markup](http://microformats.org/wiki/microformats2) for _post_ kinds.
 
-An example tumblr blog with thsi template is at https://indieweb-test.tumblr.com/
+An example Tumblr blog with this template is at https://indieweb-test.tumblr.com/
 
 This parses like this: https://xray.p3k.app/parse?url=https%3A%2F%2Findieweb-test.tumblr.com&pretty=true
 

--- a/tumblr_template.html
+++ b/tumblr_template.html
@@ -332,7 +332,7 @@
 
                                         <header class="post-header {block:Actions}show{/block:Actions}">
                                             {block:LikesPage}
-                                                <a class="post-blog p-author h-card" href="{Permalink}"><img class="blog-avatar" src="{PostBlogPortraitURL-30}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading} data-blog-card-username="{PostBlogName}">{PostBlogName}</a>
+                                                <a class="post-blog p-author h-card" href="{Permalink}"><img class="blog-avatar" alt="" src="{PostBlogPortraitURL-30}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading} data-blog-card-username="{PostBlogName}">{PostBlogName}</a>
                                             {/block:LikesPage}
                                             {block:RebloggedFrom}
                                                 <a class="reblog-link u-repost-of" href="{ReblogParentURL}" data-blog-card-username="{ReblogParentName}"><i class="reblog_sm"></i>{ReblogParentName}</a>
@@ -360,12 +360,12 @@
                                                                         <div class="post-avatar-wrapper">
                                                                             {block:IsActive}
                                                                             <a class="post-avatar-link u-url {block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                <img class="post-avatar-image u-photo" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image u-photo" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </a>
                                                                             {/block:IsActive}
                                                                             {block:IsDeactivated}
                                                                             <span class="inactive reblog-avatar{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                <img class="post-avatar-image u-photo" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image u-photo" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </span>
                                                                             {/block:IsDeactivated}
                                                                         </div>
@@ -410,12 +410,12 @@
                                                                     <div class="post-avatar-wrapper">
                                                                         {block:IsActive}
                                                                         <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </a>
                                                                         {/block:IsActive}
                                                                         {block:IsDeactivated}
                                                                         <span class="inactive reblog-avatar{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </span>
                                                                         {/block:IsDeactivated}
                                                                     </div>
@@ -456,12 +456,12 @@
                                                                     <div class="post-avatar-wrapper">
                                                                         {block:IsActive}
                                                                         <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </a>
                                                                         {/block:IsActive}
                                                                         {block:IsDeactivated}
                                                                         <span class="inactive reblog-avatar{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </span>
                                                                         {/block:IsDeactivated}
                                                                     </div>
@@ -597,12 +597,12 @@
                                                                         <div class="post-avatar-wrapper">
                                                                             {block:IsActive}
                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </a>
                                                                             {/block:IsActive}
                                                                             {block:IsDeactivated}
                                                                             <span class="inactive reblog-avatar{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </span>
                                                                             {/block:IsDeactivated}
                                                                         </div>
@@ -648,12 +648,12 @@
                                                                             <div class="post-avatar-wrapper">
                                                                                 {block:HasPermalink}
                                                                                 <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </a>
                                                                                 {/block:HasPermalink}
                                                                                 {block:HasNoPermalink}
                                                                                 <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </span>
                                                                                 {/block:HasNoPermalink}
                                                                             </div>
@@ -722,12 +722,12 @@
                                                                             <div class="post-avatar-wrapper">
                                                                                 {block:HasPermalink}
                                                                                 <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </a>
                                                                                 {/block:HasPermalink}
                                                                                 {block:HasNoPermalink}
                                                                                 <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </span>
                                                                                 {/block:HasNoPermalink}
                                                                             </div>
@@ -981,12 +981,12 @@
                                                                             <div class="post-avatar-wrapper">
                                                                                 {block:HasPermalink}
                                                                                 <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </a>
                                                                                 {/block:HasPermalink}
                                                                                 {block:HasNoPermalink}
                                                                                 <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </span>
                                                                                 {/block:HasNoPermalink}
                                                                             </div>
@@ -1038,12 +1038,12 @@
                                                                             <div class="post-avatar-wrapper">
                                                                                 {block:HasPermalink}
                                                                                 <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </a>
                                                                                 {/block:HasPermalink}
                                                                                 {block:HasNoPermalink}
                                                                                 <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                    <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                    <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                 </span>
                                                                                 {/block:HasNoPermalink}
                                                                             </div>
@@ -1088,12 +1088,12 @@
                                                                                     <div class="post-avatar-wrapper">
                                                                                         {block:HasPermalink}
                                                                                         <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                         </a>
                                                                                         {/block:HasPermalink}
                                                                                         {block:HasNoPermalink}
                                                                                         <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                         </span>
                                                                                         {/block:HasNoPermalink}
                                                                                     </div>
@@ -1169,12 +1169,12 @@
                                                                                         <div class="post-avatar-wrapper">
                                                                                             {block:HasPermalink}
                                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </a>
                                                                                             {/block:HasPermalink}
                                                                                             {block:HasNoPermalink}
                                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </span>
                                                                                             {/block:HasNoPermalink}
                                                                                         </div>
@@ -1235,12 +1235,12 @@
                                                                                         <div class="post-avatar-wrapper">
                                                                                             {block:HasPermalink}
                                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </a>
                                                                                             {/block:HasPermalink}
                                                                                             {block:HasNoPermalink}
                                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </span>
                                                                                             {/block:HasNoPermalink}
                                                                                         </div>
@@ -1288,12 +1288,12 @@
                                                                                         <div class="post-avatar-wrapper">
                                                                                             {block:HasPermalink}
                                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </a>
                                                                                             {/block:HasPermalink}
                                                                                             {block:HasNoPermalink}
                                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </span>
                                                                                             {/block:HasNoPermalink}
                                                                                         </div>
@@ -1362,12 +1362,12 @@
                                                                                         <div class="post-avatar-wrapper">
                                                                                             {block:HasPermalink}
                                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </a>
                                                                                             {/block:HasPermalink}
                                                                                             {block:HasNoPermalink}
                                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                                             </span>
                                                                                             {/block:HasNoPermalink}
                                                                                         </div>
@@ -1494,7 +1494,7 @@
                                     <article class="{block:Text}text {/block:Text}{block:Photoset}photoset {/block:Photoset}{block:Photo}photo {/block:Photo}{block:RebloggedFrom}reblogged {/block:RebloggedFrom}{block:Quote}quote {/block:Quote}{block:Link}link {/block:Link}{block:Chat}chat {/block:Chat}{block:Audio}audio {/block:Audio}{block:Video}video {/block:Video}{block:Answer}answer {/block:Answer}{block:Date}not-page post-{PostID}{/block:Date} {block:PermalinkPage} active exposed{/block:PermalinkPage}" {block:Date}data-post-id="{PostID}"{/block:Date}>
                                         <div class="post-wrapper clearfix">
                                             <header class="post-header">
-                                                    <a class="post-blog" href="{Permalink}"><img class="blog-avatar" src="{PostBlogPortraitURL-30}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading} data-blog-card-username="{PostBlogName}">{PostBlogName}</a>
+                                                    <a class="post-blog" href="{Permalink}"><img class="blog-avatar" alt="" src="{PostBlogPortraitURL-30}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading} data-blog-card-username="{PostBlogName}">{PostBlogName}</a>
                                                 {block:RebloggedFrom}
                                                     <a class="reblog-link" href="{ReblogParentURL}" data-blog-card-username="{ReblogParentName}"><i class="reblog_sm"></i>{ReblogParentName}</a>
                                                 {/block:RebloggedFrom}
@@ -1517,12 +1517,12 @@
                                                                         <div class="post-avatar-wrapper">
                                                                             {block:HasPermalink}
                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </a>
                                                                             {/block:HasPermalink}
                                                                             {block:HasNoPermalink}
                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </span>
                                                                             {/block:HasNoPermalink}
                                                                         </div>
@@ -1570,12 +1570,12 @@
                                                                     <div class="post-avatar-wrapper">
                                                                         {block:HasPermalink}
                                                                         <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </a>
                                                                         {/block:HasPermalink}
                                                                         {block:HasNoPermalink}
                                                                         <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </span>
                                                                         {/block:HasNoPermalink}
                                                                     </div>
@@ -1619,12 +1619,12 @@
                                                                     <div class="post-avatar-wrapper">
                                                                         {block:HasPermalink}
                                                                         <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </a>
                                                                         {/block:HasPermalink}
                                                                         {block:HasNoPermalink}
                                                                         <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                            <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                            <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                         </span>
                                                                         {/block:HasNoPermalink}
                                                                     </div>
@@ -1700,12 +1700,12 @@
                                                                         <div class="post-avatar-wrapper">
                                                                             {block:HasPermalink}
                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </a>
                                                                             {/block:HasPermalink}
                                                                             {block:HasNoPermalink}
                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </span>
                                                                             {/block:HasNoPermalink}
                                                                         </div>
@@ -1766,12 +1766,12 @@
                                                                         <div class="post-avatar-wrapper">
                                                                             {block:HasPermalink}
                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </a>
                                                                             {/block:HasPermalink}
                                                                             {block:HasNoPermalink}
                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </span>
                                                                             {/block:HasNoPermalink}
                                                                         </div>
@@ -1817,12 +1817,12 @@
                                                                         <div class="post-avatar-wrapper">
                                                                             {block:HasPermalink}
                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </a>
                                                                             {/block:HasPermalink}
                                                                             {block:HasNoPermalink}
                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </span>
                                                                             {/block:HasNoPermalink}
                                                                         </div>
@@ -1891,12 +1891,12 @@
                                                                         <div class="post-avatar-wrapper">
                                                                             {block:HasPermalink}
                                                                             <a class="post-avatar-link{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}" href="{Permalink}" target="_blank">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </a>
                                                                             {/block:HasPermalink}
                                                                             {block:HasNoPermalink}
                                                                             <span class="reblog-avatar{block:IsDeactivated} inactive{/block:IsDeactivated}{block:isNotOriginalEntry} sub-icon-reblog{/block:isNotOriginalEntry}">
-                                                                                <img class="post-avatar-image" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
+                                                                                <img class="post-avatar-image" alt="" src="{PortraitURL-64}"{block:IfLazyImageLoading} loading="lazy"{/block:IfLazyImageLoading}>
                                                                             </span>
                                                                             {/block:HasNoPermalink}
                                                                         </div>


### PR DESCRIPTION
This will add empty alt="" properties to the img tags in question to at least flag them as design elements. Probably should make the alt tags more descriptive, using the user's name and nicks - but unclear what the target is or if really required.